### PR TITLE
Add QmcSection_DataConnection into the resourcefilter for the _gss – DataConnection Create rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+eapowertools.png

--- a/.gitignore
+++ b/.gitignore
@@ -82,4 +82,3 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
-eapowertools.png

--- a/docs/gss_setup_guide.md
+++ b/docs/gss_setup_guide.md
@@ -198,7 +198,7 @@ Create the following security rules using the step-by-step instructions provided
 3. Name: **_gss – DataConnection Create**
     * Description: Allow users to create data connections except of type folder.
     * Actions: Create, Read, Update, Delete
-    * Resource filter: DataConnection_\*
+    * Resource filter: DataConnection_\*, QmcSection_DataConnection
     * Conditions:
     ``` 
             user.group="QlikDeveloper" 


### PR DESCRIPTION
It is impossible for a **QlikDeveloper** to access the Data Connections area in the QMC without the QmcSection_DataConnection resource filter. As long the Context is both in hub and QMC the Data Connection area should be accessible for both developers, team admins and root admins.